### PR TITLE
add requirements.txt for handling dependencies.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+httplib2
+mutagen
+google-api-python-client
+oauth2client


### PR DESCRIPTION
Instead of just listing out all the dependencies, you could just put them in a `requirements.txt` file and then instruct users to:

`pip install -r requirements.txt`

I wasn't sure, how you would like to put this message in the README, so I left that for you.