### PR TITLE
Took out album art in the description metadata

### DIFF
--- a/t2t/tune2tube.py
+++ b/t2t/tune2tube.py
@@ -297,6 +297,8 @@ description (default: True).''',
                               in list(x.values())[0])
             for tag in metalist:
                 for key in tag:
+                    if "APIC" in key:
+                        continue
                     value = tag[key]
                     nice_key = self.tunetags.tag_lookup(key, True)
                     if '\n' in value:


### PR DESCRIPTION
It kept crashing cause it was trying to add the album art metadata to the YouTube video's description so I made it skip that metadata :smile: 